### PR TITLE
WIP: Added Native YAML rule

### DIFF
--- a/rules/NativeYamlRule.py
+++ b/rules/NativeYamlRule.py
@@ -1,0 +1,13 @@
+from ansiblelint import AnsibleLintRule
+import re
+
+class NativeYamlRule(AnsibleLintRule):
+    id = '509'
+    shortdesc = ("Tasks should use native YAML syntax")
+    description = ("Instead of using the key=value shorthand, use native YAML syntax.")
+    tags = ['task']
+
+    bracket_regex = re.compile('(\s[^ ]*=([^\{\" ]*(\{\{\s[^ ]*\s\}\})?))+$')
+
+    def match(self, file, line):
+        return self.bracket_regex.search(line)


### PR DESCRIPTION
Hi,

I'm working on creating a rule for Native Yaml syntax. As per https://www.ansible.com/blog/ansible-best-practices-essentials point 3, Native YAML is best practice. If so, let's implement it as a rule.

**Is that a good idea? Feedback is welcome.**

I've added a first version in the PR. Used the following tasks to test it on:
```
- name: install telegraf
  yum:
    name: telegraf-{{ telegraf_version }} state=present update_cache=yes disable_gpg_check=yes enablerepo=telegraf
  notify: restart telegraf

- name: configure telegraf
  template: src=telegraf.conf.j2 dest=/etc/telegraf/telegraf.conf
  notify: restart telegraf

- name: start telegraf
  service: name={{ item }} state=started enabled=yes
  with_items:
    - telegraf

- name: start telegraf-helper
  service: name="{{ item }}" state=started enabled=yes
  with_items:
    - telegraf-helper

- name: debug message
  debug:
    msg: "Hello world=awesome"

- name: Replace line in file
  lineinfile:
    regexp: "^Hello"
    line: "Hello=World"
    path: /hello/world
```
It results in:
<img width="810" alt="screen shot 2018-11-26 at 10 45 40" src="https://user-images.githubusercontent.com/5196381/49006046-7664a400-f168-11e8-88dd-1c482fd4b56e.png">




Kind regards,

Ruben