### PR TITLE
Remove company name requirement

### DIFF
--- a/rules/MetaMainHasInfoRule.py
+++ b/rules/MetaMainHasInfoRule.py
@@ -4,8 +4,8 @@ from ansiblelint import AnsibleLintRule
 class MetaMainHasInfoRule(AnsibleLintRule):
     id = '701'
     shortdesc = 'meta/main.yml should contain relevant info'
-    info = ['author', 'description', 'company',
-            'license', 'min_ansible_version', 'platforms']
+    info = ['author', 'description', 'license',
+            'min_ansible_version', 'platforms']
     description = 'meta/main.yml should contain: ' + ', '.join(info)
     tags = ['metadata']
 


### PR DESCRIPTION
As many Ansible roles don't belong to a company or organisation this field should be optional and should not raise a warning. `ansible-galaxy init` also declares the field as optional. Furthermore it seems like this field is not used on Ansible Galaxy?

```yaml
galaxy_info:
  author: your name
  description: your description
  company: your company (optional)
```